### PR TITLE
proot: persistent chown using xattrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,8 @@ sh-4.2# cowsay hello rootless world
 
 - apt-get seems flaky, while yum seems almost stable (CentOS 7). Setting env var `PROOT_NO_SECCOMP=1` may mitigate the issue. (Disables seccomp acceleration)
 - apk may not work
-- chown is not implemented yet
 
 ## Future work
-
-### Persistent chown
-
-The chowned stat should be saved using a continuity manifest or an xattr value.
 
 ### OCI Runtime Hook mode
 

--- a/proot/PRoot/src/GNUmakefile
+++ b/proot/PRoot/src/GNUmakefile
@@ -15,6 +15,7 @@ OBJCOPY  = $(CROSS_COMPILE)objcopy
 OBJDUMP  = $(CROSS_COMPILE)objdump
 
 CPPFLAGS += -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -I. -I$(VPATH)
+CPPFLAGS += -DPERSISTENT_CHOWN
 CFLAGS   += -Wall -Wextra -O2
 LDFLAGS  += -L. -ltalloc -Wl,-z,noexecstack -static
 

--- a/proot/README.md
+++ b/proot/README.md
@@ -9,4 +9,13 @@ Note that the upstream version of PRoot ( https://github.com/proot-me/PRoot) is 
 
 ## Changes from the PRoot upstream
 
-- patches from udocker: https://github.com/jorge-lip/PRoot/commit/10ca3e88dc1d2e2b45439b181a168af6b4053b91
+### patches from udocker
+
+https://github.com/jorge-lip/PRoot/commit/10ca3e88dc1d2e2b45439b181a168af6b4053b91
+
+### persistent chown
+
+Following xattrs are used for storing decimal uid/gid strings:
+
+- `user.rootlesscontainers.uid`
+- `user.rootlesscontainers.gid`


### PR DESCRIPTION
following xattrs are used for storing decimal uid/gid strings:

- user.rootlesscontainers.uid
- user.rootlesscontainers.gid

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>