### PR TITLE
runrootless: disable seccomp acceleration by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ sh-4.2# cowsay hello rootless world
                 ||     ||
 ```
 
+### Environment variables
+
+- `RUNROOTLESS_SECCOMP=1`: enable seccomp acceleration (unstable)
+
 ## How it works
 
 - Transform a regular `config.json` to rootless one, and create a new OCI runtime bundle with it.
@@ -61,8 +65,8 @@ sh-4.2# cowsay hello rootless world
 
 ## Known issues
 
-- apt-get seems flaky, while yum seems almost stable (CentOS 7). Setting env var `PROOT_NO_SECCOMP=1` may mitigate the issue. (Disables seccomp acceleration)
-- apk may not work
+- `apt` / `dpkg` may crash when seccomp acceleration is enabled: https://github.com/AkihiroSuda/runrootless/issues/4
+- apk may not work: https://github.com/AkihiroSuda/runrootless/issues/3
 
 ## Future work
 

--- a/bundle/spec.go
+++ b/bundle/spec.go
@@ -3,6 +3,7 @@ package bundle
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/opencontainers/runc/libcontainer/specconv"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -42,8 +43,9 @@ func injectPRoot(spec *specs.Spec) error {
 	)
 	spec.Process.Args = append([]string{"/dev/proot/proot", "-0"}, spec.Process.Args...)
 	spec.Process.Env = append(spec.Process.Env, "PROOT_TMP_DIR=/dev/proot")
-	if v := os.Getenv("PROOT_NO_SECCOMP"); v != "" {
-		spec.Process.Env = append(spec.Process.Env, "PROOT_NO_SECCOMP="+v)
+	enableSeccomp, _ := strconv.ParseBool(os.Getenv("RUNROOTLESS_SECCOMP"))
+	if !enableSeccomp {
+		spec.Process.Env = append(spec.Process.Env, "PROOT_NO_SECCOMP=1")
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>